### PR TITLE
Ensure session directory exists in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY . .
 # Install PHP dependencies, set up the environment and clear caches
 RUN cp .env.example .env \
     && composer install --no-interaction --prefer-dist --optimize-autoloader \
+    && mkdir -p storage/framework/{cache,sessions,views} storage/logs \
     && php artisan key:generate \
     && php artisan storage:link \
     && php artisan config:clear \


### PR DESCRIPTION
## Summary
- Create Laravel storage directories during Docker build to prevent session write errors

## Testing
- `composer install` *(fails: PHP 8.4.11 not supported by locked dependencies)*
- `composer install --ignore-platform-reqs` *(fails: 403 when downloading dependencies from GitHub)*
- `docker build -t portafolio:test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f13837888324a524fecb7129795e