### PR TITLE
Ensure storage directories exist in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,13 @@ WORKDIR /var/www
 
 # Copy existing application directory contents
 COPY . .
-# Install PHP dependencies, set up the environment and clear caches
-RUN cp .env.example .env \
+# Prepare storage directories and install PHP dependencies
+RUN mkdir -p storage/framework/cache/data \
+    storage/framework/sessions \
+    storage/framework/testing \
+    storage/framework/views \
+    storage/logs \
+    && cp .env.example .env \
     && composer install --no-interaction --prefer-dist --optimize-autoloader \
     && php artisan key:generate \
     && php artisan storage:link \


### PR DESCRIPTION
## Summary
- Create Laravel storage directories during Docker build to avoid missing session file errors

## Testing
- ⚠️ `composer install` (fails: nette/schema v1.2.5 requires php 7.1 - 8.3 -> your php version (8.4.11) does not satisfy that requirement)


------
https://chatgpt.com/codex/tasks/task_e_68a7f3b068e48324a98eeaa3172d962f