### PR TITLE
docs: add APP_KEY secret instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.4-cli
+FROM php:8.2-fpm
 
 # Install system dependencies and PHP extensions required by Laravel
 RUN apt-get update && apt-get install -y \
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 # Install Composer 2.6.4
 COPY --from=composer:2.6.4 /usr/bin/composer /usr/local/bin/composer
 
-WORKDIR /var/www
+WORKDIR /var/www/html
 
 # Copy existing application directory contents
 COPY . .
@@ -33,6 +33,6 @@ RUN mkdir -p storage/framework/cache/data \
     && php artisan route:clear \
     && php artisan view:clear
 
-EXPOSE 80
+EXPOSE 9000
 
-CMD ["php", "artisan", "serve", "--host=0.0.0.0", "--port=80"]
+CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Portafolio usando Laravel 9 y Boostrap
 docker compose up --build
 ```
 
-This builds the PHP-FPM image (`ponwick/portafolio:php-fpm`) and runs it behind an nginx server using the config at `docker/nginx/default.conf`.
+This builds the PHP-FPM image (`ponwick/portafolio:php-fpm`) and runs it behind an nginx server using the config at `docker/nginx/default.conf`. The compose file preserves the image's `vendor` directory and `.env` file, so PHP-FPM is ready without extra setup.
 
 ## Kubernetes deployment
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # portafolio
 Portafolio usando Laravel 9 y Boostrap
 
+## Local development with Docker Compose
+
+```bash
+ docker-compose up
+```
+
+This setup runs PHP-FPM (`ponwick/portafolio:php-fpm`) behind an nginx server using the config at `docker/nginx/default.conf`.
+
 ## Kubernetes deployment
 
 1. **Build and push the image**

--- a/README.md
+++ b/README.md
@@ -3,11 +3,17 @@ Portafolio usando Laravel 9 y Boostrap
 
 ## Local development with Docker Compose
 
-```bash
-docker compose up --build
-```
+1. Copy the example environment file and generate an application key:
+   ```bash
+   cp .env.example .env
+   docker compose run --rm php php artisan key:generate
+   ```
+2. Start the stack:
+   ```bash
+   docker compose up --build
+   ```
 
-This builds the PHP-FPM image (`ponwick/portafolio:php-fpm`) and runs it behind an nginx server using the config at `docker/nginx/default.conf`. The compose file preserves the image's `vendor` directory and `.env` file, so PHP-FPM is ready without extra setup.
+This builds the PHP-FPM image (`ponwick/portafolio:php-fpm`) and runs it behind an nginx server using the config at `docker/nginx/default.conf`. The compose file preserves the image's `vendor` directory, while the `.env` file comes from your working copy.
 
 ## Kubernetes deployment
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # portafolio
- Portafolio usando Laravel 9 y Boostrap
+Portafolio usando Laravel 9 y Boostrap
+
+## Kubernetes deployment
+
+1. **Build and push the image**
+   ```bash
+   docker build -t <registry>/portafolio:0.0.1 .
+   docker push <registry>/portafolio:0.0.1
+   ```
+2. **Create the namespace**
+   ```bash
+   kubectl apply -f k8s/001-namespaces/namespace-portafolio.yaml
+   ```
+3. **Load TLS certificates**
+   ```bash
+   kubectl -n portafolio create secret tls tls-k8s-ponsianodeloor-dev \
+     --cert=k8s/004-cert/www_k8s-ponsianodeloor_dev.pem \
+     --key=k8s/004-cert/www_k8s-ponsianodeloor_dev.key
+   ```
+4. **Create application secrets**
+   Fill `APP_KEY` in `k8s/005-secrets/portafolio.env` with a value generated via
+   `php artisan key:generate --show` and then run:
+   ```bash
+   kubectl -n portafolio create secret generic portafolio-secrets \
+     --from-env-file=k8s/005-secrets/portafolio.env
+   ```
+5. **Deploy the application and service**
+   ```bash
+   kubectl apply -f portafolio.yaml
+   ```
+6. **Configure the Ingress**
+   ```bash
+   kubectl apply -f k8s/006-ingress-path-tls/ingress-portafolio.yaml
+   ```
+
+The Deployment uses a ConfigMap for the nginx configuration located at
+`k8s/002-configmap/portafolio-nginx-conf.yaml`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Portafolio usando Laravel 9 y Boostrap
    cp .env.example .env
    docker compose run --rm php php artisan key:generate
    ```
-2. Start the stack:
+2. Create the storage symlink so uploaded files are served from `public/storage`:
+   ```bash
+   docker compose run --rm php php artisan storage:link
+   ```
+3. Start the stack:
    ```bash
    docker compose up --build
    ```

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ Portafolio usando Laravel 9 y Boostrap
 ## Local development with Docker Compose
 
 ```bash
- docker-compose up
+docker compose up --build
 ```
 
-This setup runs PHP-FPM (`ponwick/portafolio:php-fpm`) behind an nginx server using the config at `docker/nginx/default.conf`.
+This builds the PHP-FPM image (`ponwick/portafolio:php-fpm`) and runs it behind an nginx server using the config at `docker/nginx/default.conf`.
 
 ## Kubernetes deployment
 
 1. **Build and push the image**
    ```bash
-   docker build -t <registry>/portafolio:0.0.1 .
-   docker push <registry>/portafolio:0.0.1
+   docker build -t <registry>/portafolio:php-fpm .
+   docker push <registry>/portafolio:php-fpm
    ```
 2. **Create the namespace**
    ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - .:/var/www/html
       - /var/www/html/vendor
-      - /var/www/html/.env
+      - ./.env:/var/www/html/.env
     environment:
       APP_ENV: local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: ponwick/portafolio:php-fpm
     volumes:
       - .:/var/www/html
+      - /var/www/html/vendor
+      - /var/www/html/.env
     environment:
       APP_ENV: local
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ./.env:/var/www/html/.env
     environment:
       APP_ENV: local
+    expose:
+      - "9000"
 
   nginx:
     image: nginx:1.25-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,19 @@
 version: '3.8'
 
 services:
-  app:
-    image: ponwick/portafolio:0.0.1
-    build:
-      context: .
-      dockerfile: Dockerfile
+  php:
+    image: ponwick/portafolio:php-fpm
+    volumes:
+      - .:/var/www/html
+    environment:
+      APP_ENV: local
+
+  nginx:
+    image: nginx:1.25-alpine
+    depends_on:
+      - php
     ports:
       - "80:80"
     volumes:
-      - .:/var/www
-    environment:
-      APP_ENV: local
-    command: sh -c "php artisan storage:link && php artisan serve --host=0.0.0.0 --port=80"
+      - .:/var/www/html
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.8'
-
 services:
   php:
+    build: .
     image: ponwick/portafolio:php-fpm
     volumes:
       - .:/var/www/html

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    index index.php index.html;
+    root /var/www/html/public;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_pass php:9000;
+        fastcgi_param SCRIPT_FILENAME /var/www/html/public$fastcgi_script_name;
+        fastcgi_index index.php;
+    }
+}

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,9 +8,12 @@ server {
     }
 
     location ~ \.php$ {
-        include fastcgi_params;
+        try_files $uri =404;
         fastcgi_pass php:9000;
         fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
     }
 }

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -7,6 +7,13 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
+    # Serve files stored via Laravel's storage:link symlink
+    location /storage {
+        alias /var/www/html/storage/app/public;
+        try_files $uri $uri/ /index.php?$query_string;
+        access_log off;
+    }
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_pass php:9000;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -10,7 +10,7 @@ server {
     location ~ \.php$ {
         include fastcgi_params;
         fastcgi_pass php:9000;
-        fastcgi_param SCRIPT_FILENAME /var/www/html/public$fastcgi_script_name;
         fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 }

--- a/k8s/002-configmap/portafolio-nginx-conf.yaml
+++ b/k8s/002-configmap/portafolio-nginx-conf.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portafolio-nginx-conf
+  namespace: portafolio
+data:
+  default.conf: |
+    server {
+        listen 80;
+        index index.php index.html;
+        root /var/www/html/public;
+
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location ~ \.php$ {
+            include fastcgi_params;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_param SCRIPT_FILENAME /var/www/html/public$fastcgi_script_name;
+            fastcgi_index index.php;
+        }
+    }

--- a/k8s/002-configmap/portafolio-nginx-conf.yaml
+++ b/k8s/002-configmap/portafolio-nginx-conf.yaml
@@ -14,6 +14,13 @@ data:
             try_files $uri $uri/ /index.php?$query_string;
         }
 
+        # Serve files stored in storage/app/public
+        location /storage {
+            alias /var/www/html/storage/app/public;
+            try_files $uri $uri/ /index.php?$query_string;
+            access_log off;
+        }
+
         location ~ \.php$ {
             include fastcgi_params;
             fastcgi_pass 127.0.0.1:9000;

--- a/k8s/005-secrets/readme.md
+++ b/k8s/005-secrets/readme.md
@@ -1,2 +1,9 @@
+Before creating the secret, set `APP_KEY` in `portafolio.env` with a value
+generated via `php artisan key:generate --show`.
+
+Then create the secret:
+
+```bash
 kubectl -n portafolio create secret generic portafolio-secrets \
---from-env-file=./portafolio.env
+  --from-env-file=./portafolio.env
+```

--- a/portafolio.yaml
+++ b/portafolio.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
         - name: init-copy
           image: ponwick/portafolio:php-fpm
-          command: ["sh", "-c", "cp -R /var/www/. /var/www/html"]
+          command: ["sh", "-c", "cp -a /var/www/. /var/www/html"]
           volumeMounts:
             - name: app-code
               mountPath: /var/www/html

--- a/portafolio.yaml
+++ b/portafolio.yaml
@@ -14,47 +14,74 @@ spec:
         app: portafolio
     spec:
       securityContext:
-        fsGroup: 1000          # útil si storage/logs necesita escritura
+        fsGroup: 1000
+      initContainers:
+        - name: init-copy
+          image: ponwick/portafolio:php-fpm
+          command: ["sh", "-c", "cp -R /var/www/. /var/www/html"]
+          volumeMounts:
+            - name: app-code
+              mountPath: /var/www/html
       containers:
-        - name: web
-          image: ponwick/portafolio:0.0.1
+        - name: php
+          image: ponwick/portafolio:php-fpm
           imagePullPolicy: IfNotPresent
-          ports:
-            - containerPort: 80
-
-          # 🔑 Variables típicas de Laravel
           env:
             - name: APP_ENV
               value: "production"
-            - name: APP_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: portafolio-secrets    # crea este Secret
-                  key: APP_KEY
             - name: APP_URL
               value: "https://k8s-ponsianodeloor.dev/portafolio"
             - name: ASSET_URL
               value: "https://k8s-ponsianodeloor.dev/portafolio"
-
-          # ✅ Probes en raíz del contenedor
+          envFrom:
+            - secretRef:
+                name: portafolio-secrets
+          volumeMounts:
+            - name: app-code
+              mountPath: /var/www/html
+          ports:
+            - containerPort: 9000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+        - name: nginx
+          image: nginx:1.25-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: app-code
+              mountPath: /var/www/html
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
           readinessProbe:
-            httpGet: { path: /, port: 80 }
-            initialDelaySeconds: 20
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
             periodSeconds: 10
-            timeoutSeconds: 2
-            failureThreshold: 3
-
           livenessProbe:
-            httpGet: { path: /, port: 80 }
-            initialDelaySeconds: 60
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
             periodSeconds: 20
-            timeoutSeconds: 2
-            failureThreshold: 3
-
-          startupProbe:
-            httpGet: { path: /, port: 80 }
-            periodSeconds: 5
-            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+      volumes:
+        - name: app-code
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: portafolio-nginx-conf
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- document filling APP_KEY in secret env file before creating Kubernetes secret
- add guidance on generating APP_KEY for Kubernetes secret creation

## Testing
- `composer test` (fails: Command "test" is not defined)
- `./vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68b33b5e38b48324b200d1998fb91ef9