### PR TITLE
fix ingress path

### DIFF
--- a/k8s/006-ingress-path-tls/ingress-portafolio.yaml
+++ b/k8s/006-ingress-path-tls/ingress-portafolio.yaml
@@ -18,7 +18,7 @@ spec:
     - host: k8s-ponsianodeloor.dev
       http:
         paths:
-          - path: ^/portafolio/?(.*)
+          - path: /portafolio/?(.*)
             pathType: ImplementationSpecific
             backend:
               service:


### PR DESCRIPTION
## Summary
- fix ingress path specification for portafolio ingress

## Testing
- `kubectl apply -f k8s/006-ingress-path-tls/ingress-portafolio.yaml --dry-run=client` *(fails: command not found)*
- `npm test` *(fails: missing script: "test")*
- `composer test` *(fails: command "test" is not defined)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5087843ec8324bf6db4e486910742