### PR TITLE
fix: correct init container copy path

### DIFF
--- a/portafolio.yaml
+++ b/portafolio.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
         - name: init-copy
           image: ponwick/portafolio:php-fpm-0.0.1
-          command: ["sh", "-c", "cp -a /var/www/. /var/www/html"]
+          command: ["sh", "-c", "cp -a /app/. /var/www/html"]
           volumeMounts:
             - name: app-code
               mountPath: /var/www/html


### PR DESCRIPTION
## Summary
- fix init container to copy application from /app to mounted volume

## Testing
- `kubectl apply -f portafolio.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ac40eb083249e30941da09bc2a9