### PR TITLE
Mount app code volume to temporary path in init container

### DIFF
--- a/portafolio.yaml
+++ b/portafolio.yaml
@@ -18,10 +18,10 @@ spec:
       initContainers:
         - name: init-copy
           image: ponwick/portafolio:php-fpm-0.0.1
-          command: ["sh", "-c", "cp -a /app/. /var/www/html"]
+          command: ["sh", "-c", "cp -a /var/www/html/. /app/"]
           volumeMounts:
             - name: app-code
-              mountPath: /var/www/html
+              mountPath: /app
       containers:
         - name: php
           image: ponwick/portafolio:php-fpm-0.0.1


### PR DESCRIPTION
## Summary
- copy application files from the image into the shared volume via a temporary mount path so the original `/var/www/html` remains accessible

## Testing
- `docker run --rm -it ponwick/portafolio:php-fpm-0.0.1 ls /var/www` *(fails: command not found)*
- `kubectl apply -f portafolio.yaml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b50cf8dde883248618b990b7ffe6e5